### PR TITLE
Fix editor crash by keeping logger on the main thread during reloads

### DIFF
--- a/addons/logger/LogConfig.gd
+++ b/addons/logger/LogConfig.gd
@@ -7,7 +7,7 @@ class_name LogConfig
 static func get_arguments() -> Dictionary:
 	var arguments = {}
 	var key = ""
-
+	
 	for argument in OS.get_cmdline_args():
 			var k = _parse_argument_key(argument)
 			if k != "":
@@ -15,12 +15,10 @@ static func get_arguments() -> Dictionary:
 				arguments[k] = ""
 			elif key != "":
 				arguments[key] = argument
-				# TODO: this is a no-op
 				key == ""
 			if argument.contains("="):
 				var key_value = argument.split("=")
 				arguments[key] = key_value[1]
-				# TODO: this is a no-op
 				key == ""
 	return arguments
 
@@ -35,7 +33,7 @@ static func _parse_argument_key(argument:String) -> String:
 
 static func get_steam_flag_name(name:String,prefix:String="") -> String:
 	return (prefix + name).to_lower().replace("-","_")
-
+	
 static func get_flag_name(name:String,prefix:String="") -> String:
 	return (prefix + name).to_lower().replace("_","-")
 
@@ -47,7 +45,7 @@ static func get_var(name,default=""):
 	var flag_name = get_flag_name(name)
 	var config_value = OS.get_environment(env_var_name)
 	var steam_name = get_steam_flag_name(name)
-
+	
 	var args = get_arguments()
 	if args.has(flag_name):
 		return args[flag_name]
@@ -59,7 +57,7 @@ static func get_var(name,default=""):
 
 static func get_int(name,default=0) -> int:
 	return int(get_var(name,default))
-
+	
 static func get_bool(name,default=false,prefix:String="") -> bool:
 	var v = get_var(name,default).to_lower()
 	match v:

--- a/addons/logger/LogConfig.gd
+++ b/addons/logger/LogConfig.gd
@@ -7,7 +7,7 @@ class_name LogConfig
 static func get_arguments() -> Dictionary:
 	var arguments = {}
 	var key = ""
-	
+
 	for argument in OS.get_cmdline_args():
 			var k = _parse_argument_key(argument)
 			if k != "":
@@ -15,10 +15,12 @@ static func get_arguments() -> Dictionary:
 				arguments[k] = ""
 			elif key != "":
 				arguments[key] = argument
+				# TODO: this is a no-op
 				key == ""
 			if argument.contains("="):
 				var key_value = argument.split("=")
 				arguments[key] = key_value[1]
+				# TODO: this is a no-op
 				key == ""
 	return arguments
 
@@ -33,7 +35,7 @@ static func _parse_argument_key(argument:String) -> String:
 
 static func get_steam_flag_name(name:String,prefix:String="") -> String:
 	return (prefix + name).to_lower().replace("-","_")
-	
+
 static func get_flag_name(name:String,prefix:String="") -> String:
 	return (prefix + name).to_lower().replace("_","-")
 
@@ -45,7 +47,7 @@ static func get_var(name,default=""):
 	var flag_name = get_flag_name(name)
 	var config_value = OS.get_environment(env_var_name)
 	var steam_name = get_steam_flag_name(name)
-	
+
 	var args = get_arguments()
 	if args.has(flag_name):
 		return args[flag_name]
@@ -57,7 +59,7 @@ static func get_var(name,default=""):
 
 static func get_int(name,default=0) -> int:
 	return int(get_var(name,default))
-	
+
 static func get_bool(name,default=false,prefix:String="") -> bool:
 	var v = get_var(name,default).to_lower()
 	match v:
@@ -102,7 +104,10 @@ static func get_external_log_level(log_name: String, default_level: int) -> int:
 		if LogStream.LogLevel.has(cmd_line_level):
 			return LogStream.LogLevel.find_key(cmd_line_level)
 		else:
-			Log.warn("The variable log-level is set to an illegal type, defaulting to info")
+			_warn_via_log("The variable log-level is set to an illegal type, defaulting to info")
 			return default_level
 	else:
 		return project_settings_level
+
+static func _warn_via_log(message: String) -> void:
+	push_warning(message)

--- a/addons/logger/_LogInternalPrinter.gd
+++ b/addons/logger/_LogInternalPrinter.gd
@@ -1,9 +1,9 @@
 @tool
 extends RefCounted
 
-##Intrenal singleton that handles all the printing of logs. 
-##If modifications to the logging behaviour is required, this is the place to do it. 
-##Generally, an entry is processed per message, and it is processed with _internal_log. 
+##Intrenal singleton that handles all the printing of logs.
+##If modifications to the logging behaviour is required, this is the place to do it.
+##Generally, an entry is processed per message, and it is processed with _internal_log.
 ##Using this and the methods that this calles should be a good start for editing.
 ##They are called by a separate thread and thread safe between eachother. Storing data between the threads is done through the LogStream.LogEntry class.
 class_name _LogInternalPrinter
@@ -19,6 +19,12 @@ static var _log_mutex = Mutex.new()
 static var _log_thread = Thread.new()
 ##Flag for marking when the log thread should stop looping.
 static var _is_quitting = false
+static var _is_thread_started = false
+static var _script_server: Object
+## Tracks whether logging stays on the main thread (true inside the editor).
+static var _single_threaded_mode = true
+# Used to double-check ScriptServer notifications target this script.
+const LOGGER_SCRIPT_PATH := "res://addons/logger/_LogInternalPrinter.gd"
 ##Used for benchmarking the time it takes to log a message on the main thread. Microbe is WIP, but see github.com/albinaask/Microbe for more info.
 #static var push_microbe = Microbe.new("push to queue")
 
@@ -38,6 +44,13 @@ static var MESSAGE_FORMAT_STRINGS:Array[String]
 
 ##Every method in this class is static, therefore a static constructor is used.
 static func _static_init() -> void:
+	# The Godot editor's hot-reload can call _static_init multiple times; shut down any old worker first.
+	if _is_thread_started:
+		_cleanup()
+	_is_quitting = false
+	# Runtime builds keep the background worker; editor builds force single-threaded logging.
+	_single_threaded_mode = Engine.is_editor_hint()
+
 	MESSAGE_FORMAT_STRINGS  = [
 		_settings._ensure_setting_exists(_settings.DEBUG_MESSAGE_FORMAT_KEY, _settings.DEBUG_MESSAGE_FORMAT_DEFAULT_VALUE),
 		_settings._ensure_setting_exists(_settings.INFO_MESSAGE_FORMAT_KEY, _settings.INFO_MESSAGE_FORMAT_DEFAULT_VALUE),
@@ -45,24 +58,37 @@ static func _static_init() -> void:
 		_settings._ensure_setting_exists(_settings.ERROR_MESSAGE_FORMAT_KEY, _settings.ERROR_MESSAGE_FORMAT_DEFAULT_VALUE),
 		_settings._ensure_setting_exists(_settings.FATAL_MESSAGE_FORMAT_KEY, _settings.FATAL_MESSAGE_FORMAT_DEFAULT_VALUE)
 	]
-	
+
 	var queue_size = _settings._ensure_setting_exists(_settings.LOG_QUEUE_SIZE_KEY, _settings.LOG_QUEUE_SIZE_DEFAULT_VALUE)
 	queue_size = max(queue_size, 1)#Make sure queue size is at least 1.
-	
+
 	BB_CODE_REMOVER_REGEX.compile("\\[(lb|rb)\\]|\\[.*?\\]")
 	BB_CODE_EXCLUDING_BRACKETS_REMOVER_REGEX.compile("\\[(?!(?:lb|rb)\\])[a-zA-Z0-9=_\\/]*+\\]")
 	if !ProjectSettings.settings_changed.is_connected(LogStream.sync_project_settings):
 		ProjectSettings.settings_changed.connect(LogStream.sync_project_settings)
-	if _log_thread.start(_process_logs, Thread.PRIORITY_LOW) != OK:
-		#TODO: update this to call _internal_log.
-		#TODO: Make Log able to log from same thread...
-		printerr("Log error: Couldn't create Log thread. This should never happen, please contact dev. No messages will be printed")
-	
+	if Engine.is_editor_hint() and Engine.has_singleton("ScriptServer"):
+		_script_server = Engine.get_singleton("ScriptServer")
+		# Listen for editor reloads so we can join the worker before bytecode is swapped out;
+		# without this the worker keeps running with freed bytecode and crashes on save.
+		if _script_server and !_script_server.script_changed.is_connected(_on_script_server_script_changed):
+			_script_server.script_changed.connect(_on_script_server_script_changed)
+
+	# Rebuild the queues; old LogEntry instances may still reference freed script data.
+	_front_queue = [] as Array[LogStream.LogEntry]
+	_back_queue = [] as Array[LogStream.LogEntry]
+	_front_queue_size = 0
 	_front_queue.resize(queue_size)
 	_back_queue.resize(queue_size)
 	for i in range(queue_size):
 		_front_queue[i] = LogStream.LogEntry.new()
 		_back_queue[i] = LogStream.LogEntry.new()
+
+	if !_single_threaded_mode:
+		if _log_thread.start(_process_logs, Thread.PRIORITY_LOW) != OK:
+			printerr("Log error: Couldn't create Log thread. This should never happen, please contact dev. No messages will be printed")
+		else:
+			# Track that we have a live worker so reload can shut it down first.
+			_is_thread_started = true
 
 func _ns_push_to_queue(stream_name:String, message:String, message_level:int, stream_level:int, crash_behaviour:Callable, on_log_message_signal_emission_callback:Callable, values:Variant) -> void:
 	_push_to_queue(stream_name, message, message_level, stream_level, crash_behaviour, on_log_message_signal_emission_callback, values)
@@ -75,7 +101,33 @@ static func _push_to_queue(stream_name:String, message:String, message_level:int
 	if message_level < stream_level:
 	#	push_microbe.finish()
 		return
-	
+
+	# Editor builds skip the worker thread entirely and log on the main thread here.
+	# Godot reloads editor scripts aggressively for previews/completion; keeping the
+	# background thread alive across those reloads would leave it running against
+	# freed bytecode and crash (see https://github.com/albinaask/Log/issues/22). This
+	# single-threaded path keeps the editor stable while runtime exports still use
+	# the async worker.
+	if _single_threaded_mode:
+		var entry = LogStream.LogEntry.new()
+		entry.stream_name = stream_name
+		entry.message = message
+		entry.message_level = message_level
+		entry.crash_behaviour = crash_behaviour
+		entry.values = values
+		entry.stack = get_stack()
+		if message_level >= LogStream.LogLevel.ERROR:
+			push_error(message)
+			if BREAK_ON_ERROR:
+				breakpoint
+		elif message_level == LogStream.LogLevel.WARN:
+			push_warning(message)
+		_internal_log(entry)
+		if message_level == LogStream.LogLevel.FATAL:
+			entry.crash_behaviour.call()
+		on_log_message_signal_emission_callback.call(message)
+		return
+
 	_log_mutex.lock()
 	#push_microbe.finish_sub_step("lock")
 	var entry:LogStream.LogEntry
@@ -133,7 +185,7 @@ static func _process_logs():
 		for i in range(_back_queue_size):
 			_internal_log(_back_queue[i])
 		var delta = Time.get_ticks_usec() - start
-		#Sleep for a while, depending on the time it took to process the messages, 
+		#Sleep for a while, depending on the time it took to process the messages,
 		OS.delay_usec(max(CYCLE_BREAK_TIME*1000-delta, 0))
 
 ##Main internal logging method, please use the methods in LogStream instead of this from the outside, since this is NOT thread safe in any regard and not designed to be used.
@@ -141,19 +193,20 @@ static func _internal_log(entry:LogStream.LogEntry):
 	var message = BB_CODE_REMOVER_REGEX.sub(entry.message, "", true)
 	var message_level:LogStream.LogLevel = entry.message_level
 	_reduce_stack(entry)
-	
+
 	var value_string = _stringify_values(entry.values)
-	 
+
 	if entry.stack.is_empty():#Aka is connected to debug server -> print to the editor console in addition to pushing the warning.
 		_log_mode_console(entry)
 	else:
 		_log_mode_editor(entry)
 	##AKA, level is error or fatal, the main tree is accessible and we want to print it.
-	if message_level > LogStream.LogLevel.WARN && Log.is_inside_tree() && PRINT_TREE_ON_ERROR:
-		#We want to access the main scene tree since this may be a custom logger that isn't in the main tree.
-		print("Main tree: ")
-		Log.get_tree().root.print_tree_pretty()
-		print("")#Print empty line to mark new message
+	if message_level > LogStream.LogLevel.WARN && PRINT_TREE_ON_ERROR:
+		if !_single_threaded_mode:
+			# When the worker thread is active we're off the main thread; bounce back before touching the tree.
+			Callable(_LogInternalPrinter, "_deferred_print_tree").call_deferred()
+		else:
+			_print_tree_now()
 
 static func _log_mode_editor(entry:LogStream.LogEntry):
 	var message_format_strings = MESSAGE_FORMAT_STRINGS
@@ -183,7 +236,7 @@ static func _log_mode_console(entry:LogStream.LogEntry):
 
 static func _get_format_data(entry:LogStream.LogEntry)->Dictionary:
 	var now = Time.get_datetime_dict_from_system(USE_UTC_TIME_FORMAT)
-	
+
 	var log_call = null
 	var script = ""
 	var script_class_name = ""
@@ -193,13 +246,13 @@ static func _get_format_data(entry:LogStream.LogEntry)->Dictionary:
 		script = source.split("/")[-1]
 		var result = GLOBAL_PATH_LIST.filter(func(entry):return entry["path"] == source)
 		script_class_name = script if result.is_empty() else result[0]["class"]
-	
+
 	var format_data := {
 			"log_name":entry.stream_name,
 			"message":entry.message,
 			"level":LogStream.LogLevel.keys()[entry.message_level],
 			"script": script,
-			"class": script_class_name, 
+			"class": script_class_name,
 			"function": log_call["function"] if log_call else "",
 			"line": log_call["line"] if log_call else "",
 		}
@@ -216,7 +269,7 @@ static func _get_format_data(entry:LogStream.LogEntry)->Dictionary:
 	format_data["day"] = "%02d"%now["day"]
 	format_data["month"] = "%02d"%now["month"]
 	format_data["year"] = "%04d"%now["year"]
-	
+
 	return format_data
 
 static func _stringify_values(values)->String:
@@ -265,9 +318,38 @@ static func _create_stack_string(stack:Array)->String:
 	return stack_trace_message
 
 
+##Shuts down the worker thread and disconnects editor-only hooks. Safe to call repeatedly.
 static func _cleanup():
 	_log_mutex.lock()
 	_is_quitting = true
 	_log_mutex.unlock()
-	if _log_thread.is_started():
+	# Only join the worker when we actually spawned one (runtime mode).
+	if !_single_threaded_mode and _log_thread.is_started():
 		_log_thread.wait_to_finish()
+	_is_thread_started = false
+	_log_thread = Thread.new()
+	_is_quitting = false
+	_front_queue_size = 0
+	if _script_server and _script_server.script_changed.is_connected(_on_script_server_script_changed):
+		_script_server.script_changed.disconnect(_on_script_server_script_changed)
+	_script_server = null
+
+static func _on_script_server_script_changed(script:Script) -> void:
+	if script == null:
+		return
+	if script.resource_path == LOGGER_SCRIPT_PATH:
+		_cleanup()
+
+static func _deferred_print_tree() -> void:
+	# Triggered via call_deferred(); safely re-enters the main thread before printing.
+	_print_tree_now()
+
+static func _print_tree_now() -> void:
+	var main_loop = Engine.get_main_loop()
+	if main_loop is SceneTree:
+		var tree: SceneTree = main_loop
+		if tree.root:
+			# Runs on the main thread after call_deferred() so accessing the tree is safe.
+			print("Main tree: ")
+			tree.root.print_tree_pretty()
+			print("")#Print empty line to mark new message

--- a/addons/logger/_LogInternalPrinter.gd
+++ b/addons/logger/_LogInternalPrinter.gd
@@ -204,7 +204,7 @@ static func _internal_log(entry:LogStream.LogEntry):
 	if message_level > LogStream.LogLevel.WARN && PRINT_TREE_ON_ERROR:
 		if !_single_threaded_mode:
 			# When the worker thread is active we're off the main thread; bounce back before touching the tree.
-			Callable(_LogInternalPrinter, "_deferred_print_tree").call_deferred()
+			_print_tree_now.call_deferred()
 		else:
 			_print_tree_now()
 
@@ -340,11 +340,8 @@ static func _on_script_server_script_changed(script:Script) -> void:
 	if script.resource_path == LOGGER_SCRIPT_PATH:
 		_cleanup()
 
-static func _deferred_print_tree() -> void:
-	# Triggered via call_deferred(); safely re-enters the main thread before printing.
-	_print_tree_now()
-
 static func _print_tree_now() -> void:
+	# May be reached via call_deferred() to ensure we run on the main thread before touching the tree.
 	var main_loop = Engine.get_main_loop()
 	if main_loop is SceneTree:
 		var tree: SceneTree = main_loop

--- a/addons/logger/_LogInternalPrinter.gd
+++ b/addons/logger/_LogInternalPrinter.gd
@@ -1,9 +1,9 @@
 @tool
 extends RefCounted
 
-##Intrenal singleton that handles all the printing of logs.
-##If modifications to the logging behaviour is required, this is the place to do it.
-##Generally, an entry is processed per message, and it is processed with _internal_log.
+##Intrenal singleton that handles all the printing of logs. 
+##If modifications to the logging behaviour is required, this is the place to do it. 
+##Generally, an entry is processed per message, and it is processed with _internal_log. 
 ##Using this and the methods that this calles should be a good start for editing.
 ##They are called by a separate thread and thread safe between eachother. Storing data between the threads is done through the LogStream.LogEntry class.
 class_name _LogInternalPrinter
@@ -58,10 +58,10 @@ static func _static_init() -> void:
 		_settings._ensure_setting_exists(_settings.ERROR_MESSAGE_FORMAT_KEY, _settings.ERROR_MESSAGE_FORMAT_DEFAULT_VALUE),
 		_settings._ensure_setting_exists(_settings.FATAL_MESSAGE_FORMAT_KEY, _settings.FATAL_MESSAGE_FORMAT_DEFAULT_VALUE)
 	]
-
+	
 	var queue_size = _settings._ensure_setting_exists(_settings.LOG_QUEUE_SIZE_KEY, _settings.LOG_QUEUE_SIZE_DEFAULT_VALUE)
 	queue_size = max(queue_size, 1)#Make sure queue size is at least 1.
-
+	
 	BB_CODE_REMOVER_REGEX.compile("\\[(lb|rb)\\]|\\[.*?\\]")
 	BB_CODE_EXCLUDING_BRACKETS_REMOVER_REGEX.compile("\\[(?!(?:lb|rb)\\])[a-zA-Z0-9=_\\/]*+\\]")
 	if !ProjectSettings.settings_changed.is_connected(LogStream.sync_project_settings):
@@ -72,7 +72,7 @@ static func _static_init() -> void:
 		# without this the worker keeps running with freed bytecode and crashes on save.
 		if _script_server and !_script_server.script_changed.is_connected(_on_script_server_script_changed):
 			_script_server.script_changed.connect(_on_script_server_script_changed)
-
+	
 	# Rebuild the queues; old LogEntry instances may still reference freed script data.
 	_front_queue = [] as Array[LogStream.LogEntry]
 	_back_queue = [] as Array[LogStream.LogEntry]
@@ -101,7 +101,7 @@ static func _push_to_queue(stream_name:String, message:String, message_level:int
 	if message_level < stream_level:
 	#	push_microbe.finish()
 		return
-
+	
 	# Editor builds skip the worker thread entirely and log on the main thread here.
 	# Godot reloads editor scripts aggressively for previews/completion; keeping the
 	# background thread alive across those reloads would leave it running against
@@ -185,7 +185,7 @@ static func _process_logs():
 		for i in range(_back_queue_size):
 			_internal_log(_back_queue[i])
 		var delta = Time.get_ticks_usec() - start
-		#Sleep for a while, depending on the time it took to process the messages,
+		#Sleep for a while, depending on the time it took to process the messages, 
 		OS.delay_usec(max(CYCLE_BREAK_TIME*1000-delta, 0))
 
 ##Main internal logging method, please use the methods in LogStream instead of this from the outside, since this is NOT thread safe in any regard and not designed to be used.
@@ -193,9 +193,9 @@ static func _internal_log(entry:LogStream.LogEntry):
 	var message = BB_CODE_REMOVER_REGEX.sub(entry.message, "", true)
 	var message_level:LogStream.LogLevel = entry.message_level
 	_reduce_stack(entry)
-
+	
 	var value_string = _stringify_values(entry.values)
-
+	 
 	if entry.stack.is_empty():#Aka is connected to debug server -> print to the editor console in addition to pushing the warning.
 		_log_mode_console(entry)
 	else:
@@ -236,7 +236,7 @@ static func _log_mode_console(entry:LogStream.LogEntry):
 
 static func _get_format_data(entry:LogStream.LogEntry)->Dictionary:
 	var now = Time.get_datetime_dict_from_system(USE_UTC_TIME_FORMAT)
-
+	
 	var log_call = null
 	var script = ""
 	var script_class_name = ""
@@ -246,13 +246,13 @@ static func _get_format_data(entry:LogStream.LogEntry)->Dictionary:
 		script = source.split("/")[-1]
 		var result = GLOBAL_PATH_LIST.filter(func(entry):return entry["path"] == source)
 		script_class_name = script if result.is_empty() else result[0]["class"]
-
+	
 	var format_data := {
 			"log_name":entry.stream_name,
 			"message":entry.message,
 			"level":LogStream.LogLevel.keys()[entry.message_level],
 			"script": script,
-			"class": script_class_name,
+			"class": script_class_name, 
 			"function": log_call["function"] if log_call else "",
 			"line": log_call["line"] if log_call else "",
 		}
@@ -269,7 +269,7 @@ static func _get_format_data(entry:LogStream.LogEntry)->Dictionary:
 	format_data["day"] = "%02d"%now["day"]
 	format_data["month"] = "%02d"%now["month"]
 	format_data["year"] = "%04d"%now["year"]
-
+	
 	return format_data
 
 static func _stringify_values(values)->String:

--- a/addons/logger/log-stream.gd
+++ b/addons/logger/log-stream.gd
@@ -72,7 +72,7 @@ func error(message:Variant,values:Variant=null):
 func err(message:String,values:Variant=null):
 	error(message,values)
 
-##Prints a message to the log at the fatal level, exits the application
+##Prints a message to the log at the fatal level, exits the application 
 ##since there has been a fatal error.
 func fatal(message:Variant,values:Variant=null):
 	_LogInternalPrinter._push_to_queue(_log_name, str(message), LogLevel.FATAL, current_log_level, _crash_behavior, log_message.emit, values)
@@ -96,7 +96,7 @@ func err_cond_null(arg, message_on_err:String, fatal:=true, other_values_to_be_p
 func err_cond_not_equal(arg1, arg2, message_on_err:String, fatal:=true, other_values_to_be_printed=null):
 	#The type 'Color' is weird in godot, so therefore this edgecase...
 	if (arg1 is Color && arg2 is Color && !arg1.is_equal_approx(arg2)) || arg1 != arg2:
-		_LogInternalPrinter._push_to_queue(_log_name, str(arg1) + " != " + str(arg2) + ", not allowed. " + message_on_err, LogLevel.FATAL if fatal else LogLevel.ERROR, current_log_level, _crash_behavior, log_message.emit, other_values_to_be_printed)
+		_LogInternalPrinter._push_to_queue(_log_name, str(arg1) + " != " + str(arg2) + ", not allowed. " + message_on_err, LogLevel.FATAL if fatal else LogLevel.ERROR, current_log_level, _crash_behavior, log_message.emit, other_values_to_be_printed)	
 
 ##Internal method.
 func _set_level(level:LogLevel):
@@ -128,19 +128,19 @@ static func sync_project_settings()->void:
 		settings._ensure_setting_exists(settings.FATAL_MESSAGE_FORMAT_KEY, settings.FATAL_MESSAGE_FORMAT_DEFAULT_VALUE)
 	]
 
-##Controls the behavior when a fatal error has been logged.
+##Controls the behavior when a fatal error has been logged. 
 ##Edit to customize the default behavior.
 static func default_crash_behavior()->void:
 	#Joins the logging thread(aka waits for it to log all messages that are in the queue) onto the main thread, and cleans up the logging thread.
 	_LogInternalPrinter._cleanup()
 	print("Crashing due to Fatal error.")
-	#Restart the process to the main scene. (Uncomment if wanted),
-	#note that we don't want to restart if we crash on init, then we get stuck in an infinite crash-loop, which isn't fun for anyone.
+	#Restart the process to the main scene. (Uncomment if wanted), 
+	#note that we don't want to restart if we crash on init, then we get stuck in an infinite crash-loop, which isn't fun for anyone. 
 	#if get_tree().get_frame()>0:
 	#	var _ret = OS.create_process(OS.get_executable_path(), OS.get_cmdline_args())
-
-	#Choose crash mechanism. Difference is that get_tree().quit() quits at the end of the frame,
-	#enabling multiple fatal errors to be cast, printing multiple stack traces etc.
+	
+	#Choose crash mechanism. Difference is that get_tree().quit() quits at the end of the frame, 
+	#enabling multiple fatal errors to be cast, printing multiple stack traces etc. 
 	#Warning regarding the use of OS.crash() in the docs can safely be regarded in this case.
 	OS.crash("Crash since falal error ocurred")
 	#get_tree().quit(-1)

--- a/addons/logger/log-stream.gd
+++ b/addons/logger/log-stream.gd
@@ -5,6 +5,9 @@ extends Node
 
 class_name LogStream
 
+# Preload once so log level resolution works even if LogConfig is not yet in the cache; mirrors the `_settings` naming style.
+const _log_config := preload("res://addons/logger/LogConfig.gd")
+
 enum LogLevel {
 	DEBUG = 0,
 	INFO = 1,
@@ -69,7 +72,7 @@ func error(message:Variant,values:Variant=null):
 func err(message:String,values:Variant=null):
 	error(message,values)
 
-##Prints a message to the log at the fatal level, exits the application 
+##Prints a message to the log at the fatal level, exits the application
 ##since there has been a fatal error.
 func fatal(message:Variant,values:Variant=null):
 	_LogInternalPrinter._push_to_queue(_log_name, str(message), LogLevel.FATAL, current_log_level, _crash_behavior, log_message.emit, values)
@@ -93,13 +96,19 @@ func err_cond_null(arg, message_on_err:String, fatal:=true, other_values_to_be_p
 func err_cond_not_equal(arg1, arg2, message_on_err:String, fatal:=true, other_values_to_be_printed=null):
 	#The type 'Color' is weird in godot, so therefore this edgecase...
 	if (arg1 is Color && arg2 is Color && !arg1.is_equal_approx(arg2)) || arg1 != arg2:
-		_LogInternalPrinter._push_to_queue(_log_name, str(arg1) + " != " + str(arg2) + ", not allowed. " + message_on_err, LogLevel.FATAL if fatal else LogLevel.ERROR, current_log_level, _crash_behavior, log_message.emit, other_values_to_be_printed)	
+		_LogInternalPrinter._push_to_queue(_log_name, str(arg1) + " != " + str(arg2) + ", not allowed. " + message_on_err, LogLevel.FATAL if fatal else LogLevel.ERROR, current_log_level, _crash_behavior, log_message.emit, other_values_to_be_printed)
 
 ##Internal method.
 func _set_level(level:LogLevel):
-	#level = LogConfig.get_external_log_level(_log_name, LogLevel.INFO) if level == -1 else level
-	info("setting log level to " + LogLevel.keys()[level])
-	current_log_level = level
+	var resolved_level := level
+	if level == -1:
+		# -1 is the "inherit from settings" sentinel; resolve it before logging.
+		resolved_level = _log_config.get_external_log_level(_log_name, LogLevel.INFO)
+	if resolved_level < 0 or resolved_level >= LogLevel.keys().size():
+		# Guard against unexpected values so the log never prints bogus levels.
+		resolved_level = LogLevel.INFO
+	info("setting log level to " + LogLevel.keys()[resolved_level])
+	current_log_level = resolved_level
 
 
 #make sure settings are synced without pulling them all the time. Not that this can take a tick or so.
@@ -119,19 +128,19 @@ static func sync_project_settings()->void:
 		settings._ensure_setting_exists(settings.FATAL_MESSAGE_FORMAT_KEY, settings.FATAL_MESSAGE_FORMAT_DEFAULT_VALUE)
 	]
 
-##Controls the behavior when a fatal error has been logged. 
+##Controls the behavior when a fatal error has been logged.
 ##Edit to customize the default behavior.
 static func default_crash_behavior()->void:
 	#Joins the logging thread(aka waits for it to log all messages that are in the queue) onto the main thread, and cleans up the logging thread.
 	_LogInternalPrinter._cleanup()
 	print("Crashing due to Fatal error.")
-	#Restart the process to the main scene. (Uncomment if wanted), 
-	#note that we don't want to restart if we crash on init, then we get stuck in an infinite crash-loop, which isn't fun for anyone. 
+	#Restart the process to the main scene. (Uncomment if wanted),
+	#note that we don't want to restart if we crash on init, then we get stuck in an infinite crash-loop, which isn't fun for anyone.
 	#if get_tree().get_frame()>0:
 	#	var _ret = OS.create_process(OS.get_executable_path(), OS.get_cmdline_args())
-	
-	#Choose crash mechanism. Difference is that get_tree().quit() quits at the end of the frame, 
-	#enabling multiple fatal errors to be cast, printing multiple stack traces etc. 
+
+	#Choose crash mechanism. Difference is that get_tree().quit() quits at the end of the frame,
+	#enabling multiple fatal errors to be cast, printing multiple stack traces etc.
 	#Warning regarding the use of OS.crash() in the docs can safely be regarded in this case.
 	OS.crash("Crash since falal error ocurred")
 	#get_tree().quit(-1)

--- a/addons/logger/plugin.cfg
+++ b/addons/logger/plugin.cfg
@@ -18,5 +18,5 @@ New for the fork:
 - Adds a micro benchmarking tool called Microbe.
 - Adds a test scene that can be used as an example of how the plugin can be used."
 author="albinaask, avivajpeyi, Chrisknyfe, cstaaben, florianvazelle, SeannMoser, ahrbe1"
-version="2.1.0"
+version="2.1.1"
 script="plugin.gd"

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Log"
 run/main_scene="res://tests/logtest.tscn"
-config/features=PackedStringArray("4.2", "Forward Plus")
+config/features=PackedStringArray("4.5", "Forward Plus")
 config/icon="res://icon.png"
 
 [autoload]

--- a/tests/logtest.tscn
+++ b/tests/logtest.tscn
@@ -4,7 +4,7 @@
 script/source = "extends Node
 
 var _break_on_error_current_val:bool
-var log_settings = preload(\"res://addons/logger/settings.gd\")
+var log_settings = preload(\"res://addons/logger/LogSettings.gd\")
 #Run scene to run tests.
 func _ready():
 	#save current value to reset it later for when we are done with it!


### PR DESCRIPTION
# Description

**Description**
- Hot-reload crashed on Godot 4.5 because `_LogInternalPrinter` kept a background thread alive while `_static_init()` rebuilt the logger. We now treat the editor as single-threaded, shutting down workers before ScriptServer swaps bytecode and deferring tree printing to the main thread.
- Keeps `LogStream` discoverable during reload by preloading `LogConfig` and ensures the sample scene uses the correct `LogSettings.gd` casing.
- No public API changes; runtime exports still start the worker thread, editor builds do not.

Closes #22 

<!-- For drafts, fill this in as you go; if you are done, make sure these are all done -->
#Checklist (replace space with X in the brackets to complete)

- [X] I have made corresponding changes to the documentation if applicable.
- [X] My code has passed the following test:
  - [X] Reload the editor(Project->Reload current project), since godot plugins are fiddly and some errors only shows up after the plugin context has been reloaded.
  - [X] run the res://tests/logtest.tscn scene.
  - [ ] No error messages produced. Not sure what to do there.
- [X] I have correctly bumped the version in the plugin.cfg to 2.1.1 according to the following:
  - Has form x.y.z
  - x is bumped if API breaking changes is made, these are merged restrictively.
  - y is bumped if API is added upon or modified in a way that is backwards compatible.
  - z is bumped if bugs are fixed or only internal things are changed or rearranged that doesn't change the API at all.
  - Documentation changes or comments needs no version change.
  - Read more [here](https://semver.org/) if unclear.



<!-- Thanks to: https://github.com/Team-EnderIO/EnderIO/blob/dev/1.20.1/.github/pull_request_template.md?plain=1 for the building blocks of this template -->
