### PR TITLE
Cleanup logger thread when a close is requested

### DIFF
--- a/addons/logger/_LogInternalPrinter.gd
+++ b/addons/logger/_LogInternalPrinter.gd
@@ -51,6 +51,11 @@ static func _static_init() -> void:
 	# Runtime builds keep the background worker; editor builds force single-threaded logging.
 	_single_threaded_mode = Engine.is_editor_hint()
 
+	# Cleanup when the game is being exited.
+	if not Engine.is_editor_hint():
+		var tree: SceneTree = Engine.get_main_loop()
+		tree.root.tree_exiting.connect(_cleanup)
+
 	MESSAGE_FORMAT_STRINGS  = [
 		_settings._ensure_setting_exists(_settings.DEBUG_MESSAGE_FORMAT_KEY, _settings.DEBUG_MESSAGE_FORMAT_DEFAULT_VALUE),
 		_settings._ensure_setting_exists(_settings.INFO_MESSAGE_FORMAT_KEY, _settings.INFO_MESSAGE_FORMAT_DEFAULT_VALUE),

--- a/addons/logger/log-stream.gd
+++ b/addons/logger/log-stream.gd
@@ -44,10 +44,6 @@ func _init(log_name:String, min_log_level:LogLevel=-1, crash_behavior:Callable =
 	current_log_level = min_log_level
 	_crash_behavior = crash_behavior
 
-func _ready() -> void:
-	if !get_tree().root.tree_exiting.is_connected(_LogInternalPrinter._cleanup):
-		get_tree().root.tree_exiting.connect(_LogInternalPrinter._cleanup)
-
 ##prints a message to the log at the debug level.
 func debug(message:Variant,values:Variant=null):
 	_LogInternalPrinter._push_to_queue(_log_name, str(message), LogLevel.DEBUG, current_log_level, _crash_behavior, log_message.emit, values)

--- a/addons/logger/plugin.cfg
+++ b/addons/logger/plugin.cfg
@@ -18,5 +18,5 @@ New for the fork:
 - Adds a micro benchmarking tool called Microbe.
 - Adds a test scene that can be used as an example of how the plugin can be used."
 author="albinaask, avivajpeyi, Chrisknyfe, cstaaben, florianvazelle, SeannMoser, ahrbe1"
-version="2.1.1"
+version="2.1.2"
 script="plugin.gd"


### PR DESCRIPTION
Thread objects should have their `wait_to_finish()` method called before the program exits and that wasn't happening when the game was exited. The memory the logger thread was executing could be freeded before the parent thread is terminated leading to odd errors.

As the game was being quit anyway this issue isn't the biggest deal but sometimes it results in errors in the Godot editor's console.

I decided to add an internal class to `_LogInternalPrinter` that just handles the cleaning instead of adding the logic to the `Logger` singleton because its creation is optional.

This is similar to issue #20

As stated in godotengine/godot#115832 this only seems to occur in Godot 4.6 which is odd but waiting for the thread is good nevertheless.