### PR TITLE
Added github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,50 @@
+name: Bug Report
+description: Report a bug
+labels: ["bug Report"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill out the sections below to help everyone identify and fix the bug.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe your issue
+    validations:
+      required: true
+  
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+    validations:
+      required: true
+  
+  - type: textarea
+    id: expected
+    attributes:
+      label: What was the expected result?
+      placeholder: I expected this to happen
+    validations:
+      required: true
+ 
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or videos (optional)
+ 
+  - type: dropdown
+    id: assign
+    attributes:
+      label: "Would you like to work on this issue?"
+      options:
+        - "No"
+        - "Yes"
+      default: 0
+ 
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting this issue! We will get back to you as soon as possible.

--- a/.github/ISSUE_TEMPLATE/new-feature.yml
+++ b/.github/ISSUE_TEMPLATE/new-feature.yml
@@ -1,0 +1,42 @@
+name: New feature
+description: Suggest or request a new feature
+labels: ["Feature Request"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill out the sections below to properly describe the new feature you are suggesting.
+    
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the feature
+    validations:
+      required: true
+  
+  - type: textarea
+    id: rationale
+    attributes:
+      label: It should be implemented because
+  
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      placeholder: |
+        Add any other context or screenshots about the feature request here.
+ 
+  - type: dropdown
+    id: assign
+    attributes:
+      label: "Would you like to work on this feature?"
+      options:
+        - "No"
+        - "Yes"
+      default: 0
+ 
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for your suggestion! Let's see together if it can be implemented.

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="Log"
+config/tags=PackedStringArray("addon")
 run/main_scene="res://tests/logtest.tscn"
 config/features=PackedStringArray("4.6", "Forward Plus")
 config/icon="res://icon.png"


### PR DESCRIPTION
- Bug report
- Feature request

# Description

Added github issue templates for bug report and feature requests.

### Bug Report
Form to fill in a bug report

https://github.com/user-attachments/assets/09acf110-d78b-4fe0-ad63-4ea020faf267

output:
<img width="364" height="414" alt="Screenshot_20260612_160447" src="https://github.com/user-attachments/assets/d0a4e575-44d9-451e-aaae-e39130394112" />

### Feature Request
Form to request a feature

https://github.com/user-attachments/assets/3d4b8ab4-92f1-4561-af5a-6c2cbe28dfdc

output:
<img width="465" height="337" alt="Screenshot_20260612_160358" src="https://github.com/user-attachments/assets/ee091036-56ad-44aa-b13e-59bd2881dffb" />


<!-- For drafts, fill this in as you go; if you are done, make sure these are all done -->
# Checklist (replace space with X in the brackets to complete)

- [x] I have made corresponding changes to the documentation if applicable.
- [x] My code has passed the following test:
  - Reload the editor(Project->Reload current project), since godot plugins are fiddly and some errors only shows up after the plugin context has been reloaded.
  - run the res://tests/logtest.tscn scene.
  - This should produce several error messages, among one that halts the test execution and brings up the editor debugger.
  - press ![bild](https://github.com/albinaask/Log/assets/11806563/4e4b3d51-793f-496e-8193-c96b5884f1cc) once.
  - Now this message ![bild](https://github.com/albinaask/Log/assets/11806563/c3102b55-21b3-438e-a420-56971ad98d39) should show in the engine log.
- [x] I have correctly bumped the version in the plugin.cfg according to the following:
  - Has form x.y.z
  - x is bumped if API breaking changes is made, these are merged restrictively.
  - y is bumped if API is added upon or modified in a way that is backwards compatible.
  - z is bumped if bugs are fixed or only internal things are changed or rearranged that doesn't change the API at all.
  - Documentation changes or comments needs no version change.
  - Read more [here](https://semver.org/) if unclear.
     
<!-- Thanks to: https://github.com/Team-EnderIO/EnderIO/blob/dev/1.20.1/.github/pull_request_template.md?plain=1 for the building blocks of this template -->
